### PR TITLE
Read GPL state binary data files

### DIFF
--- a/pgmatlab/loadPamguardBinaryFile.m
+++ b/pgmatlab/loadPamguardBinaryFile.m
@@ -187,6 +187,8 @@ try
                             case 'GPL Detections'
                                 fileInfo.readModuleData = @readGPLDetections;
                                 fileInfo.readBackgroundData = @readSpectralBackground;
+                            case 'GPL State'
+                                fileInfo.readModuleData = @readGPLStateData;
                         end
                     % Right Whale Edge Detector Module
                     case 'RW Edge Detector'

--- a/pgmatlab/readGPLStateData.m
+++ b/pgmatlab/readGPLStateData.m
@@ -1,0 +1,27 @@
+function [data, error] = readGPLStateData(fid, fileInfo, data)
+% reads trigger level binary data stored by the Click Detector.
+%
+% Inputs:
+%   fid = file identifier
+%   fileInfo = structure holding the file header, module header, a handle
+%   data = a structure containing the standard data
+%
+% Output:
+%   data = structure containing data from a single object
+%
+
+% initialize variables
+error=false;
+nChan = countChannels(data.channelMap);
+try
+    dataLength = fread(fid, 1, 'int32');
+    data.baseline = fread(fid, 1, 'float32');
+    data.ceilNoise = fread(fid,1, 'float32');
+    data.threshFloor = fread(fid,1, 'float32');
+    data.peakState = fread(fid,1,'int16');
+catch mError
+    disp(['Error reading ' fileInfo.fileHeader.moduleType '  data object.  Data read:']);
+    disp(data);
+    disp(getReport(mError));
+    error=true;
+end


### PR DESCRIPTION
GPL detector produces two types of binary files: detections and state. This commit adds ability to read the state files in addition to the existing ability to read the detections.